### PR TITLE
enhancement: Add API endpoint to expose media upload configuration

### DIFF
--- a/resources/types/media.d.ts
+++ b/resources/types/media.d.ts
@@ -344,6 +344,25 @@ export interface UploadConfig {
 }
 
 /**
+ * Response shape for GET /api/media/config.
+ *
+ * @since 1.2.0
+ */
+export interface MediaConfigResponse {
+    upload: {
+        max_file_size: number;
+        max_file_size_human: string;
+        allowed_mime_types: Record<string, string[]>;
+        allowed_extensions: string[];
+    };
+    image_sizes: Record<string, ImageSizeConfig>;
+    features: {
+        webp_conversion: boolean;
+        avif_conversion: boolean;
+    };
+}
+
+/**
  * Block media requirements as defined in config/artisanpack/media.php.
  */
 export interface BlockMediaRequirements {

--- a/src/Http/Controllers/MediaConfigController.php
+++ b/src/Http/Controllers/MediaConfigController.php
@@ -16,6 +16,7 @@ namespace ArtisanPackUI\MediaLibrary\Http\Controllers;
 use ArtisanPackUI\MediaLibrary\Managers\MediaManager;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Routing\Controller;
+use Symfony\Component\Mime\MimeTypes;
 
 /**
  * Media Config Controller
@@ -41,7 +42,7 @@ class MediaConfigController extends Controller
         $maxFileSizeKb = $manager->getMaxFileSize();
         $mimeTypes     = $manager->getAllowedMimeTypes();
 
-        return response()->json( [
+        $data = [
             'upload' => [
                 'max_file_size'       => $maxFileSizeKb,
                 'max_file_size_human' => $this->humanFileSize( $maxFileSizeKb * 1024 ),
@@ -53,7 +54,13 @@ class MediaConfigController extends Controller
                 'webp_conversion' => $manager->isModernFormatsEnabled() && 'webp' === $manager->getModernFormat(),
                 'avif_conversion' => $manager->isModernFormatsEnabled() && 'avif' === $manager->getModernFormat(),
             ],
-        ] );
+        ];
+
+        $etag = '"' . md5( (string) json_encode( $data ) ) . '"';
+
+        return response()->json( $data )
+            ->header( 'Cache-Control', 'public, s-maxage=3600, max-age=3600, stale-while-revalidate=86400' )
+            ->header( 'ETag', $etag );
     }
 
     /**
@@ -117,11 +124,15 @@ class MediaConfigController extends Controller
             'text/plain'                                                              => ['txt'],
         ];
 
-        $extensions = [];
+        $extensions    = [];
+        $mimeGuesser   = MimeTypes::getDefault();
 
         foreach ( $mimeTypes as $mime ) {
             if ( isset( $mimeToExtension[ $mime ] ) ) {
                 $extensions = array_merge( $extensions, $mimeToExtension[ $mime ] );
+            } else {
+                $guessed    = $mimeGuesser->getExtensions( $mime );
+                $extensions = array_merge( $extensions, $guessed );
             }
         }
 

--- a/src/Http/Controllers/MediaConfigController.php
+++ b/src/Http/Controllers/MediaConfigController.php
@@ -1,0 +1,150 @@
+<?php
+
+/**
+ * Media Config Controller
+ *
+ * Exposes the media library upload configuration via a public API endpoint
+ * so React/Vue frontend components can validate uploads client-side.
+ *
+ * @since      1.2.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\MediaLibrary\Http\Controllers;
+
+use ArtisanPackUI\MediaLibrary\Managers\MediaManager;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Routing\Controller;
+
+/**
+ * Media Config Controller
+ *
+ * Returns the server-side upload configuration (max file size, allowed MIME types,
+ * allowed extensions, image sizes, and feature flags) for client-side validation.
+ *
+ * @since   1.2.0
+ */
+class MediaConfigController extends Controller
+{
+    /**
+     * Return the media upload configuration.
+     *
+     * @since 1.2.0
+     *
+     * @param  MediaManager  $manager  The media manager instance.
+     *
+     * @return JsonResponse The media configuration response.
+     */
+    public function __invoke( MediaManager $manager ): JsonResponse
+    {
+        $maxFileSizeKb = $manager->getMaxFileSize();
+        $mimeTypes     = $manager->getAllowedMimeTypes();
+
+        return response()->json( [
+            'upload' => [
+                'max_file_size'       => $maxFileSizeKb,
+                'max_file_size_human' => $this->humanFileSize( $maxFileSizeKb * 1024 ),
+                'allowed_mime_types'  => $this->groupMimeTypes( $mimeTypes ),
+                'allowed_extensions'  => $this->extractExtensions( $mimeTypes ),
+            ],
+            'image_sizes' => $manager->getImageSizes(),
+            'features'    => [
+                'webp_conversion' => $manager->isModernFormatsEnabled() && 'webp' === $manager->getModernFormat(),
+                'avif_conversion' => $manager->isModernFormatsEnabled() && 'avif' === $manager->getModernFormat(),
+            ],
+        ] );
+    }
+
+    /**
+     * Group MIME types by their category (image, video, audio, document).
+     *
+     * @since 1.2.0
+     *
+     * @param  array<int, string>  $mimeTypes  The flat list of allowed MIME types.
+     *
+     * @return array<string, array<int, string>> MIME types grouped by category.
+     */
+    protected function groupMimeTypes( array $mimeTypes ): array
+    {
+        $grouped = [];
+
+        foreach ( $mimeTypes as $mime ) {
+            $category = explode( '/', $mime )[0] ?? 'other';
+
+            // Map application/* types to 'document'
+            if ( 'application' === $category || 'text' === $category ) {
+                $category = 'document';
+            }
+
+            $grouped[ $category ][] = $mime;
+        }
+
+        return $grouped;
+    }
+
+    /**
+     * Extract file extensions from MIME types.
+     *
+     * @since 1.2.0
+     *
+     * @param  array<int, string>  $mimeTypes  The flat list of allowed MIME types.
+     *
+     * @return array<int, string> Unique file extensions.
+     */
+    protected function extractExtensions( array $mimeTypes ): array
+    {
+        $mimeToExtension = [
+            'image/jpeg'                                                              => ['jpg', 'jpeg'],
+            'image/jpg'                                                               => ['jpg'],
+            'image/png'                                                               => ['png'],
+            'image/gif'                                                               => ['gif'],
+            'image/webp'                                                              => ['webp'],
+            'image/avif'                                                              => ['avif'],
+            'image/svg+xml'                                                           => ['svg'],
+            'application/pdf'                                                         => ['pdf'],
+            'application/msword'                                                      => ['doc'],
+            'application/vnd.openxmlformats-officedocument.wordprocessingml.document' => ['docx'],
+            'application/vnd.ms-excel'                                                => ['xls'],
+            'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'       => ['xlsx'],
+            'video/mp4'                                                               => ['mp4'],
+            'video/mpeg'                                                              => ['mpeg'],
+            'video/quicktime'                                                         => ['mov'],
+            'video/webm'                                                              => ['webm'],
+            'audio/mpeg'                                                              => ['mp3'],
+            'audio/wav'                                                               => ['wav'],
+            'audio/ogg'                                                               => ['ogg'],
+            'text/plain'                                                              => ['txt'],
+        ];
+
+        $extensions = [];
+
+        foreach ( $mimeTypes as $mime ) {
+            if ( isset( $mimeToExtension[ $mime ] ) ) {
+                $extensions = array_merge( $extensions, $mimeToExtension[ $mime ] );
+            }
+        }
+
+        return array_values( array_unique( $extensions ) );
+    }
+
+    /**
+     * Convert bytes to a human-readable file size string.
+     *
+     * @since 1.2.0
+     *
+     * @param  int  $bytes  The file size in bytes.
+     *
+     * @return string The human-readable file size.
+     */
+    protected function humanFileSize( int $bytes ): string
+    {
+        $units = ['B', 'KB', 'MB', 'GB'];
+
+        for ( $i = 0; $bytes >= 1024 && $i < count( $units ) - 1; $i++ ) {
+            $bytes /= 1024;
+        }
+
+        return round( $bytes, 1 ) . ' ' . $units[ $i ];
+    }
+}

--- a/src/routes/api.php
+++ b/src/routes/api.php
@@ -1,5 +1,6 @@
 <?php
 
+use ArtisanPackUI\MediaLibrary\Http\Controllers\MediaConfigController;
 use ArtisanPackUI\MediaLibrary\Http\Controllers\MediaController;
 use ArtisanPackUI\MediaLibrary\Http\Controllers\MediaFolderController;
 use ArtisanPackUI\MediaLibrary\Http\Controllers\MediaTagController;
@@ -13,6 +14,10 @@ use Illuminate\Support\Facades\Route;
  *
  * @since 1.0.0
  */
+
+// Public endpoint — exposes upload constraints for client-side validation.
+Route::get( 'media/config', MediaConfigController::class )->name( 'api.media.config' );
+
 Route::middleware( ['auth:sanctum'] )->group( function (): void {
     // Media Folder resource routes (before media routes to avoid conflicts)
     Route::post( 'media/folders/{id}/move', [MediaFolderController::class, 'move'] )->name( 'media.folders.move' );
@@ -27,5 +32,5 @@ Route::middleware( ['auth:sanctum'] )->group( function (): void {
     Route::get( 'media/{id}/download', [MediaController::class, 'download'] )->name( 'api.media.download' );
 
     // Media resource routes (last to avoid catching folder/tag routes)
-    Route::apiResource( 'media', MediaController::class);
-});
+    Route::apiResource( 'media', MediaController::class );
+} );

--- a/src/routes/api.php
+++ b/src/routes/api.php
@@ -9,8 +9,10 @@ use Illuminate\Support\Facades\Route;
 /**
  * Media Library API Routes
  *
- * These routes provide API endpoints for media management operations.
- * All routes require authentication and are prefixed with 'api/'.
+ * These routes provide API endpoints for media management operations
+ * and are prefixed with 'api/'. Most routes require authentication
+ * via Sanctum; public endpoints (e.g. media/config) are listed
+ * before the auth middleware group.
  *
  * @since 1.0.0
  */

--- a/tests/Feature/MediaConfigControllerTest.php
+++ b/tests/Feature/MediaConfigControllerTest.php
@@ -1,0 +1,253 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace Tests\Feature;
+
+use ArtisanPackUI\MediaLibrary\Managers\MediaManager;
+use ArtisanPackUI\MediaLibrary\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * Media Config Controller Feature Tests
+ *
+ * Tests for the GET /api/media/config endpoint that exposes
+ * upload configuration for client-side validation.
+ *
+ * @package Tests\Feature
+ *
+ * @since   1.2.0
+ */
+class MediaConfigControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->defineDatabaseMigrations();
+
+        config( [
+            'artisanpack.media.max_file_size'       => 10240,
+            'artisanpack.media.allowed_mime_types'  => [
+                'image/jpeg',
+                'image/png',
+                'image/gif',
+                'image/webp',
+                'image/svg+xml',
+                'video/mp4',
+                'video/webm',
+                'audio/mpeg',
+                'audio/wav',
+                'application/pdf',
+                'text/plain',
+            ],
+            'artisanpack.media.image_sizes' => [
+                'thumbnail' => [
+                    'width'  => 150,
+                    'height' => 150,
+                    'crop'   => true,
+                ],
+                'medium' => [
+                    'width'  => 300,
+                    'height' => 300,
+                    'crop'   => false,
+                ],
+                'large' => [
+                    'width'  => 1024,
+                    'height' => 1024,
+                    'crop'   => false,
+                ],
+            ],
+            'artisanpack.media.enable_modern_formats' => true,
+            'artisanpack.media.modern_format'         => 'webp',
+        ] );
+    }
+
+    /**
+     * Test that the config endpoint is publicly accessible without authentication.
+     */
+    public function test_config_endpoint_is_publicly_accessible(): void
+    {
+        $response = $this->getJson( '/api/media/config' );
+
+        $response->assertOk();
+    }
+
+    /**
+     * Test that the config endpoint returns the correct JSON structure.
+     */
+    public function test_config_returns_correct_structure(): void
+    {
+        $response = $this->getJson( '/api/media/config' );
+
+        $response->assertOk()
+            ->assertJsonStructure( [
+                'upload' => [
+                    'max_file_size',
+                    'max_file_size_human',
+                    'allowed_mime_types',
+                    'allowed_extensions',
+                ],
+                'image_sizes' => [
+                    'thumbnail' => ['width', 'height', 'crop'],
+                    'medium'    => ['width', 'height', 'crop'],
+                    'large'     => ['width', 'height', 'crop'],
+                ],
+                'features' => [
+                    'webp_conversion',
+                    'avif_conversion',
+                ],
+            ] );
+    }
+
+    /**
+     * Test that the config endpoint returns the correct max file size.
+     */
+    public function test_config_returns_correct_max_file_size(): void
+    {
+        $response = $this->getJson( '/api/media/config' );
+
+        $response->assertOk()
+            ->assertJsonPath( 'upload.max_file_size', 10240 )
+            ->assertJsonPath( 'upload.max_file_size_human', '10 MB' );
+    }
+
+    /**
+     * Test that MIME types are grouped by category.
+     */
+    public function test_config_groups_mime_types_by_category(): void
+    {
+        $response = $this->getJson( '/api/media/config' );
+
+        $data = $response->json();
+
+        $this->assertArrayHasKey( 'image', $data['upload']['allowed_mime_types'] );
+        $this->assertArrayHasKey( 'video', $data['upload']['allowed_mime_types'] );
+        $this->assertArrayHasKey( 'audio', $data['upload']['allowed_mime_types'] );
+        $this->assertArrayHasKey( 'document', $data['upload']['allowed_mime_types'] );
+
+        $this->assertContains( 'image/jpeg', $data['upload']['allowed_mime_types']['image'] );
+        $this->assertContains( 'video/mp4', $data['upload']['allowed_mime_types']['video'] );
+        $this->assertContains( 'audio/mpeg', $data['upload']['allowed_mime_types']['audio'] );
+        $this->assertContains( 'application/pdf', $data['upload']['allowed_mime_types']['document'] );
+        $this->assertContains( 'text/plain', $data['upload']['allowed_mime_types']['document'] );
+    }
+
+    /**
+     * Test that allowed extensions are extracted from MIME types.
+     */
+    public function test_config_returns_allowed_extensions(): void
+    {
+        $response = $this->getJson( '/api/media/config' );
+
+        $extensions = $response->json( 'upload.allowed_extensions' );
+
+        $this->assertContains( 'jpg', $extensions );
+        $this->assertContains( 'png', $extensions );
+        $this->assertContains( 'gif', $extensions );
+        $this->assertContains( 'webp', $extensions );
+        $this->assertContains( 'svg', $extensions );
+        $this->assertContains( 'mp4', $extensions );
+        $this->assertContains( 'webm', $extensions );
+        $this->assertContains( 'mp3', $extensions );
+        $this->assertContains( 'wav', $extensions );
+        $this->assertContains( 'pdf', $extensions );
+        $this->assertContains( 'txt', $extensions );
+    }
+
+    /**
+     * Test that image sizes include default config values.
+     */
+    public function test_config_returns_image_sizes(): void
+    {
+        $response = $this->getJson( '/api/media/config' );
+
+        $response->assertOk()
+            ->assertJsonPath( 'image_sizes.thumbnail.width', 150 )
+            ->assertJsonPath( 'image_sizes.thumbnail.height', 150 )
+            ->assertJsonPath( 'image_sizes.thumbnail.crop', true )
+            ->assertJsonPath( 'image_sizes.medium.width', 300 )
+            ->assertJsonPath( 'image_sizes.large.width', 1024 );
+    }
+
+    /**
+     * Test that custom registered image sizes are included.
+     */
+    public function test_config_includes_custom_image_sizes(): void
+    {
+        $manager = app( MediaManager::class );
+        $manager->registerImageSize( 'hero', 1920, 1080, false );
+
+        $response = $this->getJson( '/api/media/config' );
+
+        $response->assertOk()
+            ->assertJsonPath( 'image_sizes.hero.width', 1920 )
+            ->assertJsonPath( 'image_sizes.hero.height', 1080 )
+            ->assertJsonPath( 'image_sizes.hero.crop', false );
+    }
+
+    /**
+     * Test that feature flags reflect WebP configuration.
+     */
+    public function test_config_returns_webp_feature_flags(): void
+    {
+        config( [
+            'artisanpack.media.enable_modern_formats' => true,
+            'artisanpack.media.modern_format'         => 'webp',
+        ] );
+
+        $response = $this->getJson( '/api/media/config' );
+
+        $response->assertOk()
+            ->assertJsonPath( 'features.webp_conversion', true )
+            ->assertJsonPath( 'features.avif_conversion', false );
+    }
+
+    /**
+     * Test that feature flags reflect AVIF configuration.
+     */
+    public function test_config_returns_avif_feature_flags(): void
+    {
+        config( [
+            'artisanpack.media.enable_modern_formats' => true,
+            'artisanpack.media.modern_format'         => 'avif',
+        ] );
+
+        $response = $this->getJson( '/api/media/config' );
+
+        $response->assertOk()
+            ->assertJsonPath( 'features.webp_conversion', false )
+            ->assertJsonPath( 'features.avif_conversion', true );
+    }
+
+    /**
+     * Test that feature flags are false when modern formats are disabled.
+     */
+    public function test_config_returns_false_features_when_modern_formats_disabled(): void
+    {
+        config( [
+            'artisanpack.media.enable_modern_formats' => false,
+        ] );
+
+        $response = $this->getJson( '/api/media/config' );
+
+        $response->assertOk()
+            ->assertJsonPath( 'features.webp_conversion', false )
+            ->assertJsonPath( 'features.avif_conversion', false );
+    }
+
+    /**
+     * Test that authenticated users can also access the config endpoint.
+     */
+    public function test_config_is_accessible_by_authenticated_users(): void
+    {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs( $user )->getJson( '/api/media/config' );
+
+        $response->assertOk();
+    }
+}

--- a/tests/Feature/MediaConfigControllerTest.php
+++ b/tests/Feature/MediaConfigControllerTest.php
@@ -250,4 +250,34 @@ class MediaConfigControllerTest extends TestCase
 
         $response->assertOk();
     }
+
+    /**
+     * Test that the response includes cache headers.
+     */
+    public function test_config_response_includes_cache_headers(): void
+    {
+        $response = $this->getJson( '/api/media/config' );
+
+        $response->assertOk()
+            ->assertHeader( 'Cache-Control', 'max-age=3600, public, s-maxage=3600, stale-while-revalidate=86400' )
+            ->assertHeader( 'ETag' );
+    }
+
+    /**
+     * Test that unknown MIME types still produce extensions via Symfony fallback.
+     */
+    public function test_config_extracts_extensions_for_unknown_mime_types(): void
+    {
+        config( [
+            'artisanpack.media.allowed_mime_types' => [
+                'image/tiff',
+            ],
+        ] );
+
+        $response = $this->getJson( '/api/media/config' );
+
+        $extensions = $response->json( 'upload.allowed_extensions' );
+
+        $this->assertContains( 'tiff', $extensions );
+    }
 }

--- a/tests/Feature/MediaConfigControllerTest.php
+++ b/tests/Feature/MediaConfigControllerTest.php
@@ -259,8 +259,13 @@ class MediaConfigControllerTest extends TestCase
         $response = $this->getJson( '/api/media/config' );
 
         $response->assertOk()
-            ->assertHeader( 'Cache-Control', 'max-age=3600, public, s-maxage=3600, stale-while-revalidate=86400' )
             ->assertHeader( 'ETag' );
+
+        $cacheControl = $response->headers->get( 'Cache-Control' );
+        $this->assertStringContainsString( 'public', $cacheControl );
+        $this->assertStringContainsString( 's-maxage=3600', $cacheControl );
+        $this->assertStringContainsString( 'max-age=3600', $cacheControl );
+        $this->assertStringContainsString( 'stale-while-revalidate=86400', $cacheControl );
     }
 
     /**


### PR DESCRIPTION
## Description

Add a public `GET /api/media/config` endpoint that returns the server-side upload configuration so React and Vue frontend components can perform client-side validation before uploading files.

**Closes:** #61

## Type of Change

- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds new functionality)
- [x] Enhancement (improves existing functionality)
- [ ] Refactoring (code improvement, no behavior change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Security fix
- [ ] Breaking change (breaks backward compatibility)

## Related Issue

**Issue:** #61

## Motivation and Context

React and Vue upload components need to know the server's upload constraints (max file size, allowed MIME types, allowed extensions) for client-side validation before uploading. Previously these values were only available in the PHP config file with no way for frontend components to fetch them.

## Changes Made

- Created `MediaConfigController` (invokable) that returns upload config as JSON
- Added public `GET /api/media/config` route (no auth required — exposes configuration, not data)
- MIME types are grouped by category (image, video, audio, document)
- File extensions are extracted from allowed MIME types
- Custom image sizes registered via `apRegisterImageSize()` are included
- Feature flags reflect WebP/AVIF conversion settings
- Added `MediaConfigResponse` TypeScript interface to `media.d.ts`

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS
- PHP Version: 8.4.3
- Package Version: 1.2.x-dev

**Tests Performed:**
1. Ran full test suite — all tests passing
2. Verified endpoint is publicly accessible without authentication
3. Verified authenticated users can also access the endpoint
4. Verified custom image sizes appear in response
5. Verified feature flags toggle correctly based on config

## Accessibility Tests Run

- [x] Keyboard navigation tested — N/A (API endpoint, no UI)
- [x] Screen reader tested — N/A (API endpoint, no UI)
- [x] Color contrast verified — N/A (API endpoint, no UI)
- [x] ARIA labels checked — N/A (API endpoint, no UI)

**Details:** This is a JSON API endpoint with no UI components.

## Tests Added

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] All tests passing

**Test details:** Added `MediaConfigControllerTest` with 11 tests (66 assertions) covering:
- Public accessibility (no auth required)
- Correct JSON response structure
- Max file size and human-readable format
- MIME type grouping by category
- Extension extraction from MIME types
- Default and custom image sizes
- WebP/AVIF feature flags
- Disabled modern formats
- Authenticated user access

## Documentation

- [x] Inline code documentation added
- [ ] README updated
- [ ] Wiki updated
- [x] API documentation updated

**Documentation details:** Full PHPDoc blocks on controller and all methods. TypeScript type definition added for the response shape.

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [x] Code has been linted
- [x] Accessibility tests completed
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Public API endpoint exposing media upload configuration: max file size (numeric + human-readable), allowed MIME types grouped by category, resolved allowed extensions, predefined and custom image size presets, and WebP/AVIF availability flags; response includes caching headers (Cache-Control, ETag).

* **Tests**
  * Added feature tests validating endpoint accessibility, response structure and values, MIME grouping/extensions, image sizes, modern-format flags, and cache headers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->